### PR TITLE
Allow caching refresh adjustments

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -5,6 +5,6 @@
 
 Package|Version|Status
 -|-|-
-[Ripe.Sdk.Core](Ripe.Sdk.Core/README.md)|1.1.0|[![NuGet Build](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-core.yml/badge.svg)](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-core.yml)
-[Ripe.Sdk.DependencyInjection](Ripe.Sdk.DependencyInjection/README.md)|1.1.0|[![NuGet Build](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-dependencyinjection.yml/badge.svg)](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-dependencyinjection.yml)
+[Ripe.Sdk.Core](Ripe.Sdk.Core/README.md)|1.2.0|[![NuGet Build](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-core.yml/badge.svg)](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-core.yml)
+[Ripe.Sdk.DependencyInjection](Ripe.Sdk.DependencyInjection/README.md)|1.2.0|[![NuGet Build](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-dependencyinjection.yml/badge.svg)](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/nuget-publish-dependencyinjection.yml)
 

--- a/dotnet/Ripe.Sdk.Core/IRipeConfiguration.cs
+++ b/dotnet/Ripe.Sdk.Core/IRipeConfiguration.cs
@@ -1,15 +1,12 @@
-﻿namespace Ripe.Sdk.Core
+﻿using System;
+
+namespace Ripe.Sdk.Core
 {
     /// <summary>
     /// Interface to implement on your configuration objects
     /// </summary>
     public interface IRipeConfiguration
     {
-        /// <summary>
-        /// The interval at which the Ripe Service will refresh the cache with changes to your Ripe configuration. Used for configuring 
-        /// when to automatically attempt to refresh configuration data
-        /// </summary>
-        int TimeToLive { get; set; }
         /// <summary>
         /// The version of the Ripe API you have connected to
         /// </summary>

--- a/dotnet/Ripe.Sdk.Core/README.md
+++ b/dotnet/Ripe.Sdk.Core/README.md
@@ -17,7 +17,6 @@ Create a class that will hold your configuration, inheriting from `IRipeConfigur
 public class Config : IRipeConfiguration
 {
 	public string TestConfig { get; set; }
-	public int TimeToLive { get; set; }
 	public string ApiVersion { get; set; }
 }
 ```

--- a/dotnet/Ripe.Sdk.Core/README.md
+++ b/dotnet/Ripe.Sdk.Core/README.md
@@ -4,7 +4,7 @@
 [![Unit Tests](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/Ripe-Inc/ripe-sdks/actions/workflows/unit-tests.yml)
 
 The Ripe Core package includes the bare minimum to get started with Ripe, used mostly for Console and Desktop applications. If you're looking for 
-a package that supports modern dependency injection via the `IConfigurationBuilder`, then navigate [here](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.DependencyInjection)
+a package that supports modern dependency injection via the `IConfigurationBuilder`, then navigate [here](../Ripe.Sdk.DependencyInjection/README.md)
 
 ## Getting Started
 Install Ripe.Sdk

--- a/dotnet/Ripe.Sdk.Core/Ripe.Sdk.Core.csproj
+++ b/dotnet/Ripe.Sdk.Core/Ripe.Sdk.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
-		<Version>1.1.0</Version>
+		<Version>1.2.0</Version>
 		<Title>Ripe Sdk Core</Title>
 		<Authors>Matthew Andrews</Authors>
 		<PackageIcon>logox128.png</PackageIcon>

--- a/dotnet/Ripe.Sdk.Core/RipeOptions.cs
+++ b/dotnet/Ripe.Sdk.Core/RipeOptions.cs
@@ -17,12 +17,18 @@
         /// [Optional] The version of your application.
         /// </summary>
         string Version { get; set; }
+        /// <summary>
+        /// The number in seconds that the cached configuration lives before it is refreshed again
+        /// </summary>
+        int CacheExpiry { get; set; }
     }
     internal class RipeOptions : IRipeOptions
     {
         public string ApiKey { get; set; } = "";
         public string Uri { get; set; } = "";
         public string Version { get; set; } = "";
+        public int CacheExpiry { get; set; } = 300;
+
         public bool Validate()
         {
             if (string.IsNullOrWhiteSpace(ApiKey))

--- a/dotnet/Ripe.Sdk.Core/RipeSdk.cs
+++ b/dotnet/Ripe.Sdk.Core/RipeSdk.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;

--- a/dotnet/Ripe.Sdk.Core/RipeSdk.cs
+++ b/dotnet/Ripe.Sdk.Core/RipeSdk.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
@@ -148,8 +149,16 @@ namespace Ripe.Sdk.Core
                     Content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json")
                 };
 
-                HttpResponseMessage response = _httpClient.SendAsync(msg).Result;
-                string content = response.Content.ReadAsStringAsync().Result;
+                HttpResponseMessage response;
+                string content;
+#if NET5_0_OR_GREATER
+                response = _httpClient.Send(msg);
+                using var reader = new StreamReader(response.Content.ReadAsStream());
+                content = reader.ReadToEnd();
+#else
+                response = _httpClient.SendAsync(msg).Result;
+                content = response.Content.ReadAsStringAsync().Result;
+#endif
                 if (response.IsSuccessStatusCode)
                 {
                     var obj = JsonSerializer.Deserialize<HydrationResponse<TConfig>>(content, _serializerOptions)

--- a/dotnet/Ripe.Sdk.Core/RipeSdk.cs
+++ b/dotnet/Ripe.Sdk.Core/RipeSdk.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.IO;
+#endif
 using System.Net.Http;
 using System.Reflection;
 using System.Text;

--- a/dotnet/Ripe.Sdk.Core/RipeSdk.cs
+++ b/dotnet/Ripe.Sdk.Core/RipeSdk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -109,7 +109,7 @@ namespace Ripe.Sdk.Core
                     if (obj.Data != null)
                     {
                         _cache = obj.Data;
-                        Expiry = DateTime.Now.AddSeconds(_cache.TimeToLive);
+                        Expiry = DateTime.Now.AddSeconds(_options.CacheExpiry);
                     }
                 }
                 else
@@ -157,7 +157,7 @@ namespace Ripe.Sdk.Core
                     if (obj.Data != null)
                     {
                         _cache = obj.Data;
-                        Expiry = DateTime.Now.AddSeconds(_cache.TimeToLive);
+                        Expiry = DateTime.Now.AddSeconds(_options.CacheExpiry);
                     }
                 }
                 else

--- a/dotnet/Ripe.Sdk.DependencyInjection/README.md
+++ b/dotnet/Ripe.Sdk.DependencyInjection/README.md
@@ -7,7 +7,7 @@ The Ripe Dependency Injection package includes extensions for integrating with t
 into `IConfiguration`, as well as inject your config as a scoped service which is automatically refreshed in regular intervals.
 
 ## Getting Started
-Follow the guide [here](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.Core) to learn how to create an `IRipeConfiguration` object to base your configuration on. 
+Follow the guide [here](../Ripe.Sdk.Core/README.md) to learn how to create an `IRipeConfiguration` object to base your configuration on. 
 
 Install Ripe.Sdk.DependencyInjection
 ```

--- a/dotnet/Ripe.Sdk.DependencyInjection/Ripe.Sdk.DependencyInjection.csproj
+++ b/dotnet/Ripe.Sdk.DependencyInjection/Ripe.Sdk.DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
-		<Version>1.1.0</Version>
+		<Version>1.2.0</Version>
 		<Title>Ripe Sdk Dependency Injection</Title>
 		<Authors>Matthew Andrews</Authors>
 		<PackageIcon>logox128.png</PackageIcon>

--- a/dotnet/Ripe.Sdk.DependencyInjection/RipeConfigExtensions.cs
+++ b/dotnet/Ripe.Sdk.DependencyInjection/RipeConfigExtensions.cs
@@ -28,7 +28,7 @@ namespace Ripe.Sdk.DependencyInjection
 
         /// <summary>
         /// Add the specified Ripe configuration to your <see cref="IConfigurationBuilder"/> and inject the built configuration as a Scoped Service. 
-        /// The configuration will automatically refresh values based on Ripe environment caching details
+        /// The configuration will automatically refresh values based on the <see cref="IRipeOptions.CacheExpiry"/> value.
         /// </summary>
         /// <typeparam name="TConfig">The <see cref="IRipeConfiguration"/> that defines your Ripe configuration</typeparam>
         /// <param name="builder"></param>
@@ -43,7 +43,7 @@ namespace Ripe.Sdk.DependencyInjection
 
         /// <summary>
         /// Add the specified Ripe configuration to your <see cref="IConfigurationBuilder"/> and inject the built configuration as a Scoped Service. 
-        /// The configuration will automatically refresh values based on Ripe environment caching details.
+        /// The configuration will automatically refresh values based on the <see cref="IRipeOptions.CacheExpiry"/> value.
         /// </summary>
         /// <typeparam name="TConfig">The <see cref="IRipeConfiguration"/> that defines your Ripe configuration</typeparam>
         /// <param name="builder"></param>

--- a/dotnet/Ripe.Sdk.Tests/MockHttpMessageHandler.cs
+++ b/dotnet/Ripe.Sdk.Tests/MockHttpMessageHandler.cs
@@ -21,5 +21,9 @@ namespace Ripe.Sdk.Tests
                 Content = JsonContent.Create(new { Data = ResponseContent })
             });
         }
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return SendAsync(request, cancellationToken).Result;
+        }
     }
 }


### PR DESCRIPTION
This PR removes the `TimeToLive` property from `IRipeConfiguration` since this value has been static for quite some time. This is replaced by the `IRipeOptions` property `CacheExpiry` value, which can be set in Ripe initialization to determine how long the configuration is cached in memory. Closes #9 

This PR wraps up `1.2.0`